### PR TITLE
adds TestAgent for test and development environments

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -65,7 +65,7 @@ type StandardAgent struct {
 }
 
 //NewAgent build new StandardAgent objects.
-func NewAgent() Agent {
+func NewAgent() *StandardAgent {
 	agent := &StandardAgent{
 		NewrelicName:                DefaultAgentName,
 		NewrelicPollInterval:        DefaultNewRelicPollInterval,

--- a/agent.go
+++ b/agent.go
@@ -35,6 +35,9 @@ const (
 	DefaultAgentName = "Go daemon"
 )
 
+// ------------------
+// ------- Standard Agent
+
 //Agent - is NewRelic agent implementation.
 //Agent start separate go routine which will report data to NewRelic
 type Agent struct {
@@ -134,4 +137,33 @@ func (agent *Agent) debug(msg string) {
 	if agent.Verbose {
 		log.Println(msg)
 	}
+}
+
+// ------------------
+// ------- Test Agent
+
+type TestAgent struct{}
+
+func NewTestAgent() *TestAgent {
+	return &TestAgent{}
+}
+
+func (agent *TestAgent) WrapHTTPHandlerFunc(h tHTTPHandlerFunc) tHTTPHandlerFunc {
+	return h
+}
+
+func (agent *TestAgent) WrapHTTPHandler(h http.Handler) http.Handler {
+	return h
+}
+
+func (agent *TestAgent) Run() error {
+	return nil
+}
+
+func (agent *TestAgent) initTimer() {
+	return
+}
+
+func (agent *TestAgent) debug(msg string) {
+	return
 }


### PR DESCRIPTION
This PR adds a `TestAgent`, which implements all the same methods as the original `Agent` (now renamed to `StandardAgent`, leaving `Agent` open for the interface). 

With this addition, you can conditionally set a variable of type `Agent` to either a `TestAgent` or `StandardAgent` (depending on your env, or whatever you like) and without changing anything in your code, you can avoid reporting development/test metrics to NewRelic.