### PR TITLE
Fix build error due to dependency change

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -130,7 +130,7 @@ func (agent *Agent) Run() error {
 	agent.plugin.Client = agent.Client
 
 	var component newrelic_platform_go.IComponent
-	component = newrelic_platform_go.NewPluginComponent(agent.NewrelicName, agent.AgentGUID)
+	component = newrelic_platform_go.NewPluginComponent(agent.NewrelicName, agent.AgentGUID, agent.Verbose)
 
 	// Add default metrics and tracer.
 	addRuntimeMericsToComponent(component)


### PR DESCRIPTION
There is a dependency change - https://github.com/yvasiyarov/newrelic_platform_go/blob/db03d6dfd965ebc22dbfd910567c641b326ff055/component.go#L25

Build error - github.com/yvasiyarov/gorelic/agent.go:133: not enough arguments in call to newrelic_platform_go.NewPluginComponent