### PR TITLE
[bugfix] add verbose arg when call newrelic_platform

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -130,7 +130,7 @@ func (agent *Agent) Run() error {
 	agent.plugin.Client = agent.Client
 
 	var component newrelic_platform_go.IComponent
-	component = newrelic_platform_go.NewPluginComponent(agent.NewrelicName, agent.AgentGUID)
+	component = newrelic_platform_go.NewPluginComponent(agent.NewrelicName, agent.AgentGUID, agent.Verbose)
 
 	// Add default metrics and tracer.
 	addRuntimeMericsToComponent(component)


### PR DESCRIPTION
Can not build
```
${myGOPATH}/src/github.com/yvasiyarov/gorelic/agent.go:133: not enough arguments in call to newrelic_platform_go.NewPluginComponent
```

ref: https://github.com/yvasiyarov/newrelic_platform_go/commit/487b9669a418f80186a2f0a2bad702cf5e9ea8eb