### PR TITLE
Collect Metrics on Http Status Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you using Beego, Martini, Revel, Kami or Gin framework you can hook up goreli
 - Verbose - print some usefull for debugging information. Default value: false
 - CollectGcStat - should agent collect garbage collector statistic or not. Default value: true
 - CollectHTTPStat - should agent collect HTTP metrics. Default value: false
+- CollectHTTPStatuses - should agent collect metrics on HTTP status codes. Default value: false
 - CollectMemoryStat - should agent collect memory allocator statistic or not. Default value: true
 - GCPollInterval - how often should GC statistic collected. Default value: 10 seconds. It has performance impact. For more information, please, see metrics documentation.
 - MemoryAllocatorPollInterval - how often should memory allocator statistic collected. Default value: 60 seconds. It has performance impact. For more information, please, read metrics documentation.

--- a/agent.go
+++ b/agent.go
@@ -101,6 +101,8 @@ func (agent *Agent) WrapHTTPHandlerFunc(h tHTTPHandlerFunc) tHTTPHandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		proxy := newHTTPHandlerFunc(h)
 		proxy.timer = agent.HTTPTimer
+		//set the http status counters before serving request.
+		proxy.httpStatusCounters = agent.HTTPStatusCounters
 		proxy.ServeHTTP(w, req)
 	}
 }


### PR DESCRIPTION
The counters for Http Status codes will now be populated if the flag 'CollectHTTPStatuses' is set to true.