### PR TITLE
Fix concurrent map access errors

### DIFF
--- a/tracer_metrics_test.go
+++ b/tracer_metrics_test.go
@@ -1,0 +1,60 @@
+package gorelic
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/yvasiyarov/newrelic_platform_go"
+)
+
+var (
+	dummyComponent = newrelic_platform_go.NewPluginComponent(DefaultAgentName, DefaultAgentGuid, false)
+)
+
+func TestBeginEndTrace(t *testing.T) {
+	tracer := newTracer(dummyComponent)
+
+	trace := tracer.BeginTrace("dummy_trace")
+
+	expectedTraceName := "Trace/dummy_trace"
+	if trace.transaction.name != expectedTraceName {
+		t.Errorf("Expected the trace name to be %s but got %s instead", expectedTraceName, trace.transaction.name)
+	}
+
+	expectedMetricaModelCount := 6
+	if len(dummyComponent.MetricaModels) != expectedMetricaModelCount {
+		t.Errorf("Expected the number of metrica models to be %d but got %d instead", expectedMetricaModelCount, len(dummyComponent.MetricaModels))
+	}
+
+	var metricas []string
+	for _, metrica := range dummyComponent.MetricaModels {
+		metricas = append(metricas, metrica.GetName())
+	}
+	sort.Strings(metricas)
+
+	expectedMetricas := []string{"Trace/dummy_trace/max", "Trace/dummy_trace/mean", "Trace/dummy_trace/min", "Trace/dummy_trace/percentile75", "Trace/dummy_trace/percentile90", "Trace/dummy_trace/percentile95"}
+	if !reflect.DeepEqual(metricas, expectedMetricas) {
+		t.Errorf("Expected metricas to be %v buty got %v instead", metricas, expectedMetricas)
+	}
+
+	startTime := trace.transaction.timer.Count()
+	trace.EndTrace()
+	if trace.transaction.timer.Count() == startTime {
+		t.Error("Expected the transaction timer to be incremented")
+	}
+}
+
+func TestTrace(t *testing.T) {
+	tracer := newTracer(dummyComponent)
+
+	traceFuncExecuted := false
+	dummyTraceFunc := func() {
+		traceFuncExecuted = true
+	}
+	tracer.Trace("dummy_trace", dummyTraceFunc)
+
+	if !traceFuncExecuted {
+		t.Fatal("Trace func was not executed")
+	}
+}


### PR DESCRIPTION
Hey @yvasiyarov, we're using this library for a web server and we noticed that the Tracer metrics map is not protected by locks in `BeginTrace`, which sometimes causes a fatal error (concurrent map read and map write).

I took a stab at fixing this issue and I took the liberty to write some tests for tracer_metrics.go. Please let me know if you are interested in merging this and if there is anything that you'd like to see changed before merging.